### PR TITLE
added auto create sessions on section creation/update

### DIFF
--- a/backend/src/controllers/sections.ts
+++ b/backend/src/controllers/sections.ts
@@ -16,7 +16,7 @@ const populateSessions = async (section: SectionDoc) => {
   const sectionStartDate = new Date(section.startDate);
   const sessionDates = [];
 
-  let sessionDate = new Date(sectionStartDate);
+  let sessionDate = new Date(sectionStartDate) > today ? new Date(sectionStartDate) : today;
   while (sessionDate >= today && sessionDate <= sectionEndDate) {
     if (
       section.days.includes(

--- a/backend/src/controllers/sections.ts
+++ b/backend/src/controllers/sections.ts
@@ -9,27 +9,35 @@ import type { RequestHandler, Response } from "express";
 const handleError = (res: Response, message: string, status = 400) =>
   res.status(status).json({ message });
 
+// Populate sessions list
+const populateSessions = async (section: SectionDoc) => {
+  const today = new Date();
+  const sectionEndDate = new Date(section.endDate);
+  const sectionStartDate = new Date(section.startDate);
+  const sessionDates = [];
+
+  let sessionDate = new Date(sectionStartDate);
+  while (sessionDate >= today && sessionDate <= sectionEndDate) {
+    if (
+      section.days.includes(
+        sessionDate.toLocaleDateString("en-US", { weekday: "long", timeZone: "UTC" }),
+      )
+    ) {
+      sessionDates.push(new Date(sessionDate));
+    }
+    sessionDate = new Date(sessionDate.setDate(sessionDate.getDate() + 1));
+  }
+
+  return sessionDates;
+};
+
 // ---------------------- CREATE ----------------------
 export const createSection: RequestHandler = async (req, res) => {
   try {
     const section = new Section(req.body);
     await section.save();
 
-    const sectionEndDate = new Date(section.endDate);
-    const sectionStartDate = new Date(section.startDate);
-    const sessionDates = [];
-
-    let sessionDate = new Date(sectionStartDate);
-    while (sessionDate <= sectionEndDate) {
-      if (
-        section.days.includes(
-          sessionDate.toLocaleDateString("en-US", { weekday: "long", timeZone: "UTC" }),
-        )
-      ) {
-        sessionDates.push(new Date(sessionDate));
-      }
-      sessionDate = new Date(sessionDate.setDate(sessionDate.getDate() + 1));
-    }
+    const sessionDates = await populateSessions(section);
 
     await Promise.all(
       sessionDates.map(async (date: Date) => {
@@ -77,21 +85,9 @@ export const updateSection: RequestHandler<{ id: string }, unknown, UpdateSectio
       return handleError(res, `Section ${req.params.id} not found`, 404);
     }
 
-    const sectionEndDate = new Date(section.endDate);
-    const sectionStartDate = new Date(section.startDate);
-    const sessionDates = [];
+    await SessionModel.deleteMany({ section: section._id, sessionDate: { $gt: new Date() } });
 
-    let sessionDate = new Date(sectionStartDate);
-    while (sessionDate <= sectionEndDate) {
-      if (
-        section.days.includes(
-          sessionDate.toLocaleDateString("en-US", { weekday: "long", timeZone: "UTC" }),
-        )
-      ) {
-        sessionDates.push(new Date(sessionDate));
-      }
-      sessionDate = new Date(sessionDate.setDate(sessionDate.getDate() + 1));
-    }
+    const sessionDates = await populateSessions(section);
 
     await Promise.all(
       sessionDates.map(async (date: Date) => {

--- a/backend/src/controllers/sections.ts
+++ b/backend/src/controllers/sections.ts
@@ -1,4 +1,5 @@
 import { Section } from "../models/sections";
+import { SessionModel } from "../models/session";
 
 import type { SectionDoc } from "../models/sections";
 // controllers/sections.ts
@@ -13,6 +14,32 @@ export const createSection: RequestHandler = async (req, res) => {
   try {
     const section = new Section(req.body);
     await section.save();
+
+    const sectionEndDate = new Date(section.endDate);
+    const sectionStartDate = new Date(section.startDate);
+    const sessionDates = [];
+
+    let sessionDate = new Date(sectionStartDate);
+    while (sessionDate <= sectionEndDate) {
+      if (
+        section.days.includes(
+          sessionDate.toLocaleDateString("en-US", { weekday: "long", timeZone: "UTC" }),
+        )
+      ) {
+        sessionDates.push(new Date(sessionDate));
+      }
+      sessionDate = new Date(sessionDate.setDate(sessionDate.getDate() + 1));
+    }
+
+    await Promise.all(
+      sessionDates.map(async (date: Date) => {
+        await SessionModel.create({
+          section: section._id,
+          sessionDate: date,
+        });
+      }),
+    );
+
     res.status(201).json(section);
   } catch (error: unknown) {
     handleError(res, error instanceof Error ? error.message : "Unknown error");
@@ -49,6 +76,34 @@ export const updateSection: RequestHandler<{ id: string }, unknown, UpdateSectio
     if (!section) {
       return handleError(res, `Section ${req.params.id} not found`, 404);
     }
+
+    const sectionEndDate = new Date(section.endDate);
+    const sectionStartDate = new Date(section.startDate);
+    const sessionDates = [];
+
+    let sessionDate = new Date(sectionStartDate);
+    while (sessionDate <= sectionEndDate) {
+      if (
+        section.days.includes(
+          sessionDate.toLocaleDateString("en-US", { weekday: "long", timeZone: "UTC" }),
+        )
+      ) {
+        sessionDates.push(new Date(sessionDate));
+      }
+      sessionDate = new Date(sessionDate.setDate(sessionDate.getDate() + 1));
+    }
+
+    await Promise.all(
+      sessionDates.map(async (date: Date) => {
+        const session = await SessionModel.findOne({ section: section._id, sessionDate: date });
+        if (!session) {
+          await SessionModel.create({
+            section: section._id,
+            sessionDate: date,
+          });
+        }
+      }),
+    );
 
     res.json(section);
   } catch (error: unknown) {

--- a/backend/src/models/sections.ts
+++ b/backend/src/models/sections.ts
@@ -57,6 +57,7 @@ const sectionSchema = new mongoose.Schema(
     },
     color: {
       type: String,
+      default: "#ff00ff",
     },
     days: {
       type: [String],

--- a/backend/src/validators/sections.ts
+++ b/backend/src/validators/sections.ts
@@ -147,6 +147,6 @@ export const updateSectionValidator = [
   makeEndDateValidator(),
   makeDateOrderValidator(),
   makeArchivedValidator(),
-  makeColorValidator(),
+  makeColorValidator().optional(),
   ...validateTeachers.map((v) => v.optional()),
 ];


### PR DESCRIPTION
## Tracking Info

Resolves #46

## Changes

sessions get automatically created when section is created or updated (old sessions do not get overwritten)

## Testing

postman testing

## Confirmation of Change

### Creating section
<img width="2546" height="1597" alt="image" src="https://github.com/user-attachments/assets/56868850-fc22-498c-8dd2-fb17e5dd974b" />

### Sessions for the section
<img width="2558" height="1599" alt="image" src="https://github.com/user-attachments/assets/e67828f5-8104-40fd-a411-ba6e64f171f9" />

### Updating section
<img width="2559" height="1596" alt="image" src="https://github.com/user-attachments/assets/49bd0966-4ae6-4a68-b164-eb13c58d2d61" />

### Sessions after updating section
<img width="2559" height="1599" alt="image" src="https://github.com/user-attachments/assets/d6247d6e-d04b-4034-bf96-083d25e171fd" />

Observe that the ids of 2 of the old sessions do not change.
