### PR TITLE
fix: fixed bug

### DIFF
--- a/frontend/src/app/(pages)/attendance/page.tsx
+++ b/frontend/src/app/(pages)/attendance/page.tsx
@@ -72,8 +72,10 @@ export default function Attendance() {
   });
 
   const handleSectionChange = (sectionId: string) => {
-    setActiveSectionId(sectionId);
-    setActiveDate(""); // reset date when section changes
+    if (sectionId !== activeSectionId) {
+      setActiveSectionId(sectionId);
+      setActiveDate(""); // reset date when section changes to force user to select a date, preventing mismatch between section and date
+    }
   };
 
   // Once we have sessions for the section, auto-select today if available, else first date


### PR DESCRIPTION
## Tracking Info

Resolves #59 

## Changes
fixed bug where you select an older date in the attendance page, then select the same section which would change the date picker to say "(TODAY)" despite not being today.

Behavior now: just does nothing when you reselect the same section.
- TODO
NA

## Testing
I just tested the same steps in the video.

- TODO
NA

## Confirmation of Change
I just did the same thing in the video.

TODO
NA