### PR TITLE
Styling fix

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -53,9 +53,9 @@
     --grey-400: #b6b8ba;
     --grey-500: #666666;
     --grey-600: #6c6a6b;
-    --grey-700: #3f3f3f;
+    --grey-700: #494445;
     --grey-800: #2a2a2a;
-    --grey-900: #1a1a1a;
+    --grey-900: #231f20;
     --grey-950: #0d0d0d;
 
     --primary-25: #f9fdfc;

--- a/frontend/src/components/AddStaff/AddStaffForm.module.css
+++ b/frontend/src/components/AddStaff/AddStaffForm.module.css
@@ -4,7 +4,7 @@
   flex-direction: column;
 
   font-family: "Montserrat", sans-serif;
-  color: black;
+  color: var(--grey-700);
 
   width: 100%;
   max-width: 640px;
@@ -21,6 +21,7 @@
   font-weight: 600;
   margin: 0;
   margin-bottom: 48px;
+  color: var(--grey-900);
 }
 
 .formPage {

--- a/frontend/src/components/MultiSelect/MultiSelect.module.css
+++ b/frontend/src/components/MultiSelect/MultiSelect.module.css
@@ -208,7 +208,7 @@
 .boldenIcon {
   color: var(--grey-900) !important;
   filter: brightness(0.45);
-  font-weight: 300;
+  font-weight: 500;
 }
 
 .boldenText {

--- a/frontend/src/components/StudentStaffTable/Page.module.css
+++ b/frontend/src/components/StudentStaffTable/Page.module.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
+  height: 100vh;
   background-color: #fcfbfb;
   padding: 64px 128px 0 128px;
 

--- a/frontend/src/components/studentform/StudentForm.module.css
+++ b/frontend/src/components/studentform/StudentForm.module.css
@@ -4,7 +4,7 @@
   flex-direction: column;
 
   font-family: "Montserrat", sans-serif;
-  color: black;
+  color: var(--grey-700);
 
   padding: 10px;
   width: 100%;
@@ -26,6 +26,7 @@
   font-size: 30px;
   font-weight: 600;
   margin-bottom: 0;
+  color: var(--grey-900);
 }
 .description {
   font-size: 12px;


### PR DESCRIPTION
## Tracking Info


## Changes

Fixed student/staff page styling issue where the table component did not take up the full height of the page. Updated MultiSelect styling to integrate into header bars better. I increased the font weight when boldenContent=True, which only selects elements in the header bar. Updated student and staff form colors to match Figma and updated global variables to match Figma.

## Testing

I reviewed the changes I made to ensure they matched the Figma design.

- TODO

## Confirmation of Change

### Student/Staff table fix
Before:
<img width="1175" height="657" alt="image" src="https://github.com/user-attachments/assets/e8c5664e-bc1b-40df-9c33-7a3c78d144ca" />
After:
<img width="1079" height="923" alt="image" src="https://github.com/user-attachments/assets/d8275b4f-1d19-4d0a-b648-1fbbd233bc09" />

### MultiSelect fix
Before: 
<img width="470" height="67" alt="image" src="https://github.com/user-attachments/assets/7ae0f206-eac7-40b7-9449-df455cff21f5" />
After:
<img width="480" height="72" alt="image" src="https://github.com/user-attachments/assets/00b91987-857f-45ab-a1fe-f4b52dd063b4" />
