### PR TITLE
Navbar styling fixes

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2531,7 +2531,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5241,7 +5241,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
@@ -7249,7 +7249,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7950,7 +7950,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7963,7 +7963,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9051,7 +9051,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/frontend/src/components/Navbar/Navbar.module.css
+++ b/frontend/src/components/Navbar/Navbar.module.css
@@ -34,12 +34,14 @@
 
   .navLink {
     border-radius: 6px;
+    padding: 10px;
+    display: flex;
   }
 
   .navIcon {
-    width: clamp(8px, 100%, 60px);
-    padding: 10px;
-    border-radius: 6px;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
   }
 
   .navLink:not(.activeNavLink):hover {
@@ -75,15 +77,18 @@
   .logoutBtn {
     background: none;
     border: none;
-    padding: 14px;
+    padding: 10px;
     cursor: pointer;
     border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .logoutIcon {
     width: 20px;
     height: 20px;
-    display: block;
+    flex-shrink: 0;
   }
 
   .logoutBtn:hover {

--- a/frontend/src/components/Navbar/Navbar.module.css
+++ b/frontend/src/components/Navbar/Navbar.module.css
@@ -14,39 +14,45 @@
 
   border-right: 1px solid var(--grey-200);
 
-  .logo {
-    width: 2rem;
-    transition: transform 0.2s ease-in-out;
-    filter: none;
-    background: none;
+  .logoLink {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
+    padding: 6px;
     margin-top: 0.5rem;
   }
 
-  .logo:hover {
-    transform: scale(1.3);
+  .logoLink:hover {
+    background-color: var(--grey-50);
+  }
+
+  .logo {
+    width: 2rem;
+    filter: none;
   }
 
   .navLink {
-    border-radius: 4px;
+    border-radius: 6px;
   }
 
   .navIcon {
     width: clamp(8px, 100%, 60px);
     padding: 10px;
-    border-radius: 4px;
+    border-radius: 6px;
   }
 
-  .navLink:hover {
+  .navLink:not(.activeNavLink):hover {
     background-color: var(--grey-50);
   }
 
-  .navLink:hover .navIcon {
+  .navLink:not(.activeNavLink):hover .navIcon {
     filter: brightness(0) invert(0.5);
   }
 
   .activeNavLink {
     background-color: var(--primary-500);
-    border-radius: 4px;
+    border-radius: 6px;
   }
 
   .activeNavLink .navIcon {
@@ -69,12 +75,18 @@
   .logoutBtn {
     background: none;
     border: none;
-    padding: 0;
+    padding: 14px;
     cursor: pointer;
-    transition: transform 0.15s ease-in-out;
+    border-radius: 6px;
+  }
+
+  .logoutIcon {
+    width: 20px;
+    height: 20px;
+    display: block;
   }
 
   .logoutBtn:hover {
-    transform: scale(1.2);
+    background-color: var(--grey-50);
   }
 }

--- a/frontend/src/components/Navbar/Navbar.module.css
+++ b/frontend/src/components/Navbar/Navbar.module.css
@@ -4,6 +4,8 @@
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
+  background: white;
+  z-index: 1;
 
   width: clamp(60px, 7vw, 80px);
   height: 100vh;

--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -44,7 +44,7 @@ export function Navbar() {
   return (
     <nav className={style.sideNav}>
       <div className={style.navLinks}>
-        <Link href="/programs">
+        <Link href="/programs" className={style.logoLink}>
           <Image
             src="/icons/logo.png"
             className={style.logo}
@@ -80,7 +80,13 @@ export function Navbar() {
       </div>
 
       <button onClick={handleLogout} className={style.logoutBtn} aria-label="Log out">
-        <Image src="/icons/nav/logout.svg" alt="Logout icon" width={20} height={20} />
+        <Image
+          src="/icons/nav/logout.svg"
+          alt="Logout icon"
+          width={20}
+          height={20}
+          className={style.logoutIcon}
+        />
       </button>
     </nav>
   );


### PR DESCRIPTION
## Tracking Info

Resolves #83 

## Changes

- Add white background color and z-index of 1 to navbar component to prevent tables from clipping underneath
- Change hover effects for logo and logout button to be more consistent with figma/other navbar buttons
  - Previously, the hover effects of logo and logout button made the icons bigger instead of having a gray background
  - Now, they have a gray background like the other navbar buttons
  - I also made sure that the hover effect does not apply for the active tab
- Prevent navbar button icons from shrinking for mobile/smaller screen sizes
  - (logout button icon became very small for mobile so that's why I decided to look into this)
  - note: logo still changes sizes but I left it since I thought it looked fine
- **note**: does NOT include tooltip for logout button
- **note 2**: maybe we can consider adding a state for when a button is being actively clicked (?), this PR does not address this


## Testing

- manually checked by going to localhost:3000 and making sure the navbar appears on top of all tables on all pages

## Confirmation of Change

### Before

https://github.com/user-attachments/assets/38c5c78e-cbd0-4afe-8068-766fa3e3c2ff


### After
Prevent clipping + hover effects: 

https://github.com/user-attachments/assets/49fc65e1-e70a-422b-a588-ccc1d713e3f8

Navbar buttons no longer shrink (aside from logo):

https://github.com/user-attachments/assets/9058f6f8-c060-4fea-8da3-85ce3d6dab08
